### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,12 @@ plugins {
     id "com.github.hierynomus.license" version "0.15.0"
     id "org.asciidoctor.convert" version "2.0-alpha.5"
     id "org.ajoberstar.git-publish" version "2.0.0"
+    id 'com.gradle.build-scan' version '1.16'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 project.version.with {

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 }
 
 plugins {
+    id 'com.gradle.build-scan' version '1.16'
     id 'java-gradle-plugin'
     id 'groovy'
     id 'maven-publish'
@@ -25,7 +26,6 @@ plugins {
     id "com.github.hierynomus.license" version "0.15.0"
     id "org.asciidoctor.convert" version "2.0-alpha.5"
     id "org.ajoberstar.git-publish" version "2.0.0"
-    id 'com.gradle.build-scan' version '1.16'
 }
 
 buildScan {

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
-./gradlew $GRADLE_BUILD_OPTS build asciidoc
+./gradlew $GRADLE_BUILD_OPTS build asciidoc --scan
 
 if [ "${TRAVIS_PULL_REQUEST}" == "false" -a "${TRAVIS_BRANCH}" == "master" ]; then
   if [ "`git ls-remote origin gh-pages`" == "" ]; then


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.