### PR TITLE
Handle non-modular jars with troublesome names

### DIFF
--- a/src/main/groovy/org/beryx/jlink/util/Util.groovy
+++ b/src/main/groovy/org/beryx/jlink/util/Util.groovy
@@ -95,7 +95,7 @@ class Util {
             return ModuleFinder.of(f.toPath()).findAll().first().descriptor().name()
         } catch (Exception e) {
             def modName = getFallbackModuleName(f)
-            LOGGER.warn("Cannot retrieve the module name of $f. Using fallback value: $modName.", e)
+            LOGGER.warn("Cannot retrieve the module name of $f. Using fallback value: $modName.")
             return modName
         }
     }
@@ -104,10 +104,10 @@ class Util {
         def modName = new JarFile(f).getManifest()?.mainAttributes?.getValue('Automatic-Module-Name')
         if(modName) return modName
         def s = f.name
-        def tokens = s.split('-[0-9]')
+        def tokens = s.split('[_.0-9]*-[0-9]')
         if(tokens.length < 2) return s - '.jar'
         def len = s.length()
-        return s.substring(0, len - tokens[tokens.length-1].length() - 2).replace('-', '.')
+        return tokens[0].replace('-', '.').replace('default', 'dflt')
     }
 
     @CompileDynamic
@@ -190,9 +190,9 @@ class Util {
     }
 
     static boolean isEmptyJar(File jarFile) {
-        def zipFile = new ZipFile(jarFile)
+            def zipFile = new ZipFile(jarFile)
         zipFile.entries().every { ZipEntry entry -> entry.name in ['META-INF/', 'META-INF/MANIFEST.MF']}
-    }
+     }
 
     @CompileDynamic
     static DirectoryProperty createDirectoryProperty(Project project) {


### PR DESCRIPTION
I'm dependent on [TrueVFS](http://truevfs.net) in my application, but many of its jars, as well as some of its indirect dependencies, have troublesome names which prevents them to be used as automatic modules.
The very same problem prevents this plugin from making delegated modules for them, since the `getFallbackModuleName` method fails to return a valid name.

This workaround uses a wider split pattern in `getFallbackModuleName` in order to get rid of 'version numbers' embedded in the module name, e.g. of '`truevfs-profile-base_2.12-0.12.0.jar`'.

Also, replace 'default' with 'dflt', e.g. in '`truecommons-key-default-2.5.0.ja`r'.

(Hopefully, later versions of all these troublesome jars will get Automatic-Module-Name attributes by their authors.)