### PR TITLE
MacOS fixes

### DIFF
--- a/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
@@ -82,9 +82,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                 if(!new File(currImagePath).directory) {
                     throw new GradleException("Unable to find the application image in ${td.jpackageData.getImageOutputDir()}")
                 }
-                LOGGER.info("Fix app-image for Mac OS: moving $currImagePath to $appImagePath/app")
-                appImageDir.mkdirs()
-                project.ant.move file: currImagePath, tofile: "$appImagePath/app"
+                appImagePath = currImagePath
             }
         }
 
@@ -100,7 +98,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                            '--overwrite',
                            '--output', td.jpackageData.getInstallerOutputDir(),
                            '--name', jpd.installerName,
-                           '--app-image', "${td.jpackageData.getImageOutputDir()}/$jpd.imageName",
+                           '--app-image', "$appImagePath",
                            *jpd.installerOptions]
         }
         if(result.exitValue != 0) {


### PR DESCRIPTION
A bug in jpackage required that the application image had an 'app' subdirectory. This has now been fixed (in jpackage EA build 18, hopefully available sometime next week), and present work-around here can be removed.
Also, use the corrected appImageName (suffixed with ".app")  when calling create-installer.