### PR TITLE
jpackage option '--overwrite' is gone in build 30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     implementation localGroovy()
 
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.6'
 
     plugin "org.ow2.asm:asm:$asmVersion"
     plugin "org.ow2.asm:asm-commons:$asmVersion"

--- a/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
@@ -17,6 +17,7 @@ package org.beryx.jlink.impl
 
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import org.apache.commons.io.FileUtils
 import org.beryx.jlink.data.JPackageTaskData
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -50,11 +51,10 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
             project.ext.jpackageImageOutput = {
                 return standardOutput.toString()
             }
-
+            FileUtils.cleanDirectory(td.jpackageData.getImageOutputDir())
             def jpd = td.jpackageData
             commandLine = ["$jpd.jpackageHome/bin/jpackage",
                             'create-image',
-                            '--overwrite',
                             '--output', td.jpackageData.getImageOutputDir(),
                             '--name', jpd.imageName,
                             '--module-path', td.jlinkJarsDir,
@@ -94,10 +94,11 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
             project.ext.jpackageInstallerOutput = {
                 return standardOutput.toString()
             }
+            if (td.jpackageData.getImageOutputDir() != td.jpackageData.getInstallerOutputDir())
+                FileUtils.cleanDirectory(td.jpackageData.getInstallerOutputDir())
             commandLine = ["$jpd.jpackageHome/bin/jpackage",
                            'create-installer',
                            *(jpd.installerType ? ['--installer-type', jpd.installerType] : []),
-                           '--overwrite',
                            '--output', td.jpackageData.getInstallerOutputDir(),
                            '--name', jpd.installerName,
                            '--app-image', "${td.jpackageData.getImageOutputDir()}/$jpd.imageName",


### PR DESCRIPTION
jpackage option '--overwrite' is gone in build 30 and we need to clean the output directory before creating the image.

Please also accept PR #35  to make the plugin fully compatible with build 30.