### PR TITLE
Feature/jpackage fixes

### DIFF
--- a/src/main/groovy/org/beryx/jlink/JPackageTask.groovy
+++ b/src/main/groovy/org/beryx/jlink/JPackageTask.groovy
@@ -24,6 +24,7 @@ import org.beryx.jlink.impl.JPackageTaskImpl
 import org.beryx.jlink.impl.JlinkTaskImpl
 import org.beryx.jlink.util.PathUtil
 import org.beryx.jlink.util.Util
+import org.gradle.api.Task
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
@@ -53,7 +54,7 @@ class JPackageTask extends BaseTask {
     Property<JPackageData> jpackageData
 
     JPackageTask() {
-        dependsOn(JlinkPlugin.TASK_NAME_PREPARE_MODULES_DIR)
+        dependsOn(JlinkPlugin.TASK_NAME_JLINK)
         description = 'Creates an installable image using the jpackage tool'
     }
 
@@ -79,6 +80,8 @@ class JPackageTask extends BaseTask {
         taskData.jpackageData = jpackageData.get()
         taskData.mainClass = mainClass.get() ?: defaultMainClass
         taskData.jlinkJarsDir = jlinkJarsDir.get().asFile
+        def JlinkTask jlinkTask = (JlinkTask) project.getTasksByName(JlinkPlugin.TASK_NAME_JLINK, false).first() // Should be one, and only one
+        taskData.jlinkImageDir = jlinkTask.imageDirAsFile
 
         def taskImpl = new JPackageTaskImpl(project, taskData)
         taskImpl.execute()

--- a/src/main/groovy/org/beryx/jlink/data/JPackageTaskData.groovy
+++ b/src/main/groovy/org/beryx/jlink/data/JPackageTaskData.groovy
@@ -25,5 +25,6 @@ class JPackageTaskData extends BaseTaskData {
     String mainClass
     File jlinkJarsDir
     File imageDir
+    File jlinkImageDir
     JPackageData jpackageData
 }

--- a/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
@@ -59,7 +59,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                            '--name', jpd.imageName,
                            '--module-path', td.jlinkJarsDir,
                            '--module', "$td.moduleName/$td.mainClass",
-                           *(jpd.jvmArgs ? ['--jvm-args', '"' + jpd.jvmArgs.join(' ')+ '"'] : []),
+                           *(jpd.jvmArgs ? jpd.jvmArgs.collect{['--jvm-args', '"'+it+'"']}.flatten() : []),
                            *jpd.imageOptions]
         }
         if(result.exitValue != 0) {

--- a/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
@@ -59,6 +59,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                            '--name', jpd.imageName,
                            '--module-path', td.jlinkJarsDir,
                            '--module', "$td.moduleName/$td.mainClass",
+                           '--runtime-image', td.jlinkImageDir,
                            *(jpd.jvmArgs ? jpd.jvmArgs.collect{['--jvm-args', '"'+it+'"']}.flatten() : []),
                            *jpd.imageOptions]
         }


### PR DESCRIPTION
This PR fixes two bugs:

 1. The `jpackage` task should invoke _jpackage create-image_ with the argument `--runtime-image` to specify the image we have previously built in the `jlink`task.
 2. The `jvmArgs`option, a list of String, should be passed as multiple `--jvm-args` arguments to `jpackage create-image`. It was previously passed as a single concatenated string.

Point 1 above necessitates that the `jpackage` task is dependent on the `jlink` task. This has also been fixed.

(Could you please review my lookup of the "jlink" task in `JPackageTask.groovy`? Is it really OK to do by calling `getTasksByName(...)`?)