### PR TITLE
feat: provide an --resource-dir option to jpackage

### DIFF
--- a/doc/user_guide.adoc
+++ b/doc/user_guide.adoc
@@ -409,6 +409,10 @@ imageOptions:: list of additional options to be passed to the `jpackage` executa
     _defaultValue_: empty list +
     _usage example_: `imageOptions = ["--win-console"]`
 
+resourceDir:: the directory passed as argument to the `--resource-dir` option when running `jpackage` to create an application installer.
+It is also applicable when creating an application image when you want your own application image instead of the default java image. +
+    _usage example_: `resourceDir = file("$buildDir/my-packaging-resources")`
+
 skipInstaller:: boolean value that lets you generate only the platform-specific application image and skip the generation of the platform-specific application installer. +
     _defaultValue_: false +
     _usage example_: `skipInstaller = true`

--- a/src/main/groovy/org/beryx/jlink/data/JPackageData.groovy
+++ b/src/main/groovy/org/beryx/jlink/data/JPackageData.groovy
@@ -19,6 +19,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.ToString
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import static org.beryx.jlink.util.Util.EXEC_EXTENSION
@@ -42,6 +43,9 @@ class JPackageData {
 
     @Input
     List<String> imageOptions = []
+
+    @Input @Optional
+    File resourceDir
 
     @Input @Optional
     String targetPlatformName
@@ -78,6 +82,11 @@ class JPackageData {
     @Input
     String getInstallerName() {
         this.@installerName ?: launcherData.name ?: project.name
+    }
+
+    @InputDirectory
+    File getResourceDir() {
+        this.@resourceDir
     }
 
     @Input

--- a/src/main/groovy/org/beryx/jlink/impl/JPackageImageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageImageTaskImpl.groovy
@@ -72,12 +72,16 @@ class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                 propFiles[launcher.name] = propFile
             }
 
+            final def resourceDir = jpd.getResourceDir()
+            final def resourceOpts = (resourceDir == null) ? [] : [ '--resource-dir', resourceDir ]
+
             commandLine = [jpackageExec,
                            '--output', outputDir,
                            '--name', jpd.imageName,
                            '--module-path', td.jlinkJarsDir,
                            '--module', "$td.moduleName/$td.mainClass",
                            '--runtime-image', td.runtimeImageDir,
+                           *resourceOpts,
                            *(jpd.jvmArgs ? jpd.jvmArgs.collect{['--java-options', adjustArg(it)]}.flatten() : []),
                            *(jpd.args ? jpd.args.collect{['--arguments', adjustArg(it)]}.flatten() : []),
                            *(propFiles ? propFiles.collect{['--add-launcher', it.key + '=' +  it.value.absolutePath]}.flatten() : []),

--- a/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
@@ -62,12 +62,17 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                 if (td.jpackageData.getImageOutputDir() != td.jpackageData.getInstallerOutputDir()) {
                     FileUtils.cleanDirectory(td.jpackageData.getInstallerOutputDir())
                 }
+
+                final def resourceDir = jpd.getResourceDir()
+                final def resourceOpts = (resourceDir == null) ? [] : [ '--resource-dir', resourceDir ]
+
                 commandLine = ["$jpd.jpackageHome/bin/jpackage",
                                '--package-type', packageType,
                                '--output', td.jpackageData.getInstallerOutputDir(),
                                '--name', jpd.installerName,
                                '--identifier', jpd.identifier ?: td.mainClass,
                                '--app-image', "$appImagePath",
+                               *resourceOpts,
                                *jpd.installerOptions]
             }
             if(result.exitValue != 0) {


### PR DESCRIPTION
Add resource directory argument to jpackage.
This allows for further customization of both application image and installer.
Same feature was added to the badass-runtime-plugin.