### PR TITLE
feat: provide an --app-version option to jpackage

### DIFF
--- a/doc/user_guide.adoc
+++ b/doc/user_guide.adoc
@@ -433,6 +433,10 @@ identifier:: the argument passed to the `--identifier` option when running `jpac
     _defaultValue_: the main class name +
     _usage example_: `identifier = "org.example.MyApp"`
 
+appVersion:: the argument passed to the `--app-version` option when running `jpackage` when executing the `jpackage` and `jpackageImage` tasks. +
+    _defaultValue_: the project version +
+    _usage example_: `appVersion = "1.0.0"`
+
 jvmArgs:: list of JVM arguments to be passed to the virtual machine. +
     _defaultValue_: the `jvmArgs` value configured in the `launcher` block or an empty list
 

--- a/src/main/groovy/org/beryx/jlink/data/JPackageData.groovy
+++ b/src/main/groovy/org/beryx/jlink/data/JPackageData.groovy
@@ -63,6 +63,9 @@ class JPackageData {
     @Input @Optional
     String identifier
 
+    @Input @Optional
+    String appVersion
+
     @Input
     List<String> installerOptions = []
 

--- a/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
@@ -63,6 +63,12 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                     FileUtils.cleanDirectory(td.jpackageData.getInstallerOutputDir())
                 }
 
+                def appVersion = (jpd.appVersion ?: project.version).toString()
+                def versionOpts = (appVersion == 'unspecified') ? [] : [ '--app-version', appVersion ]
+                if (versionOpts && (!appVersion || !Character.isDigit(appVersion[0] as char))) {
+                    throw new GradleException("The first character of the --app-version argument should be a digit.")
+                }
+
                 final def resourceDir = jpd.getResourceDir()
                 final def resourceOpts = (resourceDir == null) ? [] : [ '--resource-dir', resourceDir ]
 
@@ -71,6 +77,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                                '--output', td.jpackageData.getInstallerOutputDir(),
                                '--name', jpd.installerName,
                                '--identifier', jpd.identifier ?: td.mainClass,
+                               *versionOpts,
                                '--app-image', "$appImagePath",
                                *resourceOpts,
                                *jpd.installerOptions]


### PR DESCRIPTION
Add option for --app-version to jpackage. Will default to project.version. If project version has not been specified it will not set --app-version argument.