### PR TITLE
Rename output to dest for jpackage task

### DIFF
--- a/src/main/groovy/org/beryx/jlink/data/JPackageData.groovy
+++ b/src/main/groovy/org/beryx/jlink/data/JPackageData.groovy
@@ -61,9 +61,6 @@ class JPackageData {
     String installerName
 
     @Input @Optional
-    String identifier
-
-    @Input @Optional
     String appVersion
 
     @Input

--- a/src/main/groovy/org/beryx/jlink/impl/JPackageImageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageImageTaskImpl.groovy
@@ -83,7 +83,7 @@ class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
             final def resourceOpts = (resourceDir == null) ? [] : [ '--resource-dir', resourceDir ]
 
             commandLine = [jpackageExec,
-                           '--output', outputDir,
+                           '--dest', outputDir,
                            '--name', jpd.imageName,
                            '--module-path', td.jlinkJarsDir,
                            '--module', "$td.moduleName/$td.mainClass",

--- a/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
@@ -80,7 +80,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
 
                 commandLine = [jpackageExec,
                                '--package-type', packageType,
-                               '--output', td.jpackageData.getInstallerOutputDir(),
+                               '--dest', td.jpackageData.getInstallerOutputDir(),
                                '--name', jpd.installerName,
                                '--identifier', jpd.identifier ?: td.mainClass,
                                *versionOpts,

--- a/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JPackageTaskImpl.groovy
@@ -82,7 +82,6 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                                '--package-type', packageType,
                                '--dest', td.jpackageData.getInstallerOutputDir(),
                                '--name', jpd.installerName,
-                               '--identifier', jpd.identifier ?: td.mainClass,
                                *versionOpts,
                                '--app-image', "$appImagePath",
                                *resourceOpts,


### PR DESCRIPTION
The latest version of jpackage was just made public and there the `--output` argument was renamed to `--dest`. See https://openjdk.java.net/jeps/343. I've not yet tested if these were the only breaking changes. See here for a list of all changes: https://mail.openjdk.java.net/pipermail/core-libs-dev/2019-October/062682.html