### PR TITLE
Switch automatic build to GitHub Actions

### DIFF
--- a/.github/workflows/buld-jlink-plugin.yml
+++ b/.github/workflows/buld-jlink-plugin.yml
@@ -1,0 +1,27 @@
+name: Java 11 Gradle CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Grant execute permission for publish.sh
+      run: chmod +x publish.sh
+    - name: Build with Gradle
+      run: ./gradlew $GRADLE_BUILD_OPTS build asciidoc --scan
+    - name: Run publish if necessary
+      run: ./publish.sh

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ev
+
+if [ "${github.ref}" == "master" ]; then
+  if [ "$(git ls-remote origin gh-pages)" == "" ]; then
+    echo Start gitPublishPush with ghPageType=init
+    ./gradlew --no-daemon -i -s gitPublishPush --rerun-tasks -PghPageType=init
+    echo Finished gitPublishPush with ghPageType=init
+  fi
+  echo Start gitPublishPush with ghPageType=latest
+  ./gradlew --no-daemon -i -s gitPublishPush --rerun-tasks -PghPageType=latest
+  echo Finished gitPublishPush with ghPageType=version
+
+  echo Start gitPublishPush with ghPageType=version
+  ./gradlew --no-daemon -i -s gitPublishPush --rerun-tasks -PghPageType=version
+  echo Finished gitPublishPush with ghPageType=version
+
+  echo Start updating releases.md
+  ./gradlew --no-daemon -i -s update-release-list gitPublishPush --rerun-tasks -PghPageType=list
+  echo Finished updating releases.md
+fi


### PR DESCRIPTION
This PR addresses #119 . However, there is a problem with it. One of the tests fails in Github Actions:

`org.beryx.jlink.ModuleInfoAdjusterSpec > should adjust module descriptors FAILED
    Condition not satisfied:

    qExports == [ 'sun.awt to [jdk.unsupported.desktop, jdk.accessibility, my.merged.module]', 'java.awt.dnd.peer to [jdk.unsupported.desktop]', 'sun.swing to [jdk.unsupported.desktop]', 'sun.awt.dnd to [jdk.unsupported.desktop]', ] as Set
    |        |
    |        false
    [sun.awt to [jdk.unsupported.desktop, my.merged.module, jdk.accessibility], java.awt.dnd.peer to [jdk.unsupported.desktop], sun.swing to [jdk.unsupported.desktop], sun.awt.dnd to [jdk.unsupported.desktop]]
        at org.beryx.jlink.ModuleInfoAdjusterSpec.should adjust module descriptors(ModuleInfoAdjusterSpec.groovy:47)
`


Problem is simple: Order of modules is different, but I'm not really an expert in Groovy testing and I don't know an easy way to fix it. I was thinking that we can force alphabetical order in those modules, but this decision needs to be made. Please provide me with advice and I will adjust my PR.


I'm not yet removing Travis build.  Let's have Github Actions build stable and only after that we'll remove old Travis build.