### PR TITLE
fix #244 secondary launcher fails in Kotlin DSL

### DIFF
--- a/src/main/groovy/org/beryx/jlink/data/JlinkPluginExtension.groovy
+++ b/src/main/groovy/org/beryx/jlink/data/JlinkPluginExtension.groovy
@@ -174,7 +174,7 @@ class JlinkPluginExtension {
         action.execute(launcherData.get())
     }
 
-    void secondaryLauncher(Action<LauncherData> action) {
+    void secondaryLauncher(Action<SecondaryLauncherData> action) {
         def ld = new SecondaryLauncherData(null)
         ld.moduleName = moduleName.get()
         Util.addToListProperty(secondaryLaunchers, ld)

--- a/src/test/groovy/org/beryx/jlink/JlinkPluginSpec.groovy
+++ b/src/test/groovy/org/beryx/jlink/JlinkPluginSpec.groovy
@@ -223,6 +223,24 @@ class JlinkPluginSpec extends Specification {
         checkOutput(result, 'howdy', 'Howdy!')
     }
 
+    def "should create image of project with multiple launchers using kotlin DSL"() {
+        when:
+
+        File buildFile = setUpBuild('multi-launch-kotlin-dsl')
+        BuildResult result = GradleRunner.create()
+                .withDebug(true)
+                .withGradleVersion('7.6')
+                .withProjectDir(testProjectDir.toFile())
+                .withPluginClasspath()
+                .withArguments(JlinkPlugin.TASK_NAME_JLINK, "-is")
+                .build();
+
+        then:
+        checkOutput(result, 'hello', 'Hello, world!')
+        checkOutput(result, 'helloAgain', 'Hello again!')
+        checkOutput(result, 'howdy', 'Howdy!')
+    }
+
     private boolean checkOutput(BuildResult result, String imageName, String expectedOutput) {
         def imageBinDir = new File(testProjectDir.toFile(), 'build/image/bin')
         def launcherExt = OperatingSystem.current.windows ? '.bat' : ''

--- a/src/test/resources/multi-launch-kotlin-dsl/build.gradle.kts
+++ b/src/test/resources/multi-launch-kotlin-dsl/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    id("org.javamodularity.moduleplugin") version "1.8.12"
+    id("org.beryx.jlink")
+}
+
+repositories {
+    mavenCentral()
+}
+
+extra["moduleName"] = "org.example.multi"
+
+application {
+    mainClass.set("org.example.multi.Hello")
+}
+
+jlink {
+    launcher {
+        name = "hello"
+        noConsole = false
+        jvmArgs = listOf(
+            "-Xms512m",
+            "-Xmx4g",
+            "-XX:+UseShenandoahGC"
+        )
+    }
+    secondaryLauncher {
+        name = "helloAgain"
+        mainClass = "org.example.multi.HelloAgain"
+    }
+    secondaryLauncher {
+        name = "howdy"
+        moduleName= "org.example.multi"
+        mainClass = "org.example.multi.Howdy"
+    }
+}

--- a/src/test/resources/multi-launch-kotlin-dsl/settings.gradle.kts
+++ b/src/test/resources/multi-launch-kotlin-dsl/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "multi-launch-kotlin-dsl"

--- a/src/test/resources/multi-launch-kotlin-dsl/src/main/java/module-info.java
+++ b/src/test/resources/multi-launch-kotlin-dsl/src/main/java/module-info.java
@@ -1,0 +1,2 @@
+module org.example.multi {
+}

--- a/src/test/resources/multi-launch-kotlin-dsl/src/main/java/org/example/multi/Hello.java
+++ b/src/test/resources/multi-launch-kotlin-dsl/src/main/java/org/example/multi/Hello.java
@@ -1,0 +1,7 @@
+package org.example.multi;
+
+public class Hello {
+    public static void main(String[] args) {
+		System.out.println("Hello, world!");
+    }
+}

--- a/src/test/resources/multi-launch-kotlin-dsl/src/main/java/org/example/multi/HelloAgain.java
+++ b/src/test/resources/multi-launch-kotlin-dsl/src/main/java/org/example/multi/HelloAgain.java
@@ -1,0 +1,7 @@
+package org.example.multi;
+
+public class HelloAgain {
+    public static void main(String[] args) {
+		System.out.println("Hello again!");
+    }
+}

--- a/src/test/resources/multi-launch-kotlin-dsl/src/main/java/org/example/multi/Howdy.java
+++ b/src/test/resources/multi-launch-kotlin-dsl/src/main/java/org/example/multi/Howdy.java
@@ -1,0 +1,7 @@
+package org.example.multi;
+
+public class Howdy {
+    public static void main(String[] args) {
+		System.out.println("Howdy!");
+    }
+}


### PR DESCRIPTION
This fixes #244. The actual fix is just one line of code, changing `void secondaryLauncher(Action<LauncherData> action)  ` to `void secondaryLauncher(Action<SecondaryLauncherData> action)  `.

The rest is a test case that I copied from "multi-launch" and changed the build scripts to use the Kotlin DSL. I verified that the test fails without the fix applied and passes with it.