### PR TITLE
feat: Fix missing jmods folder

### DIFF
--- a/src/main/groovy/org/beryx/jlink/impl/JlinkTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/jlink/impl/JlinkTaskImpl.groovy
@@ -76,7 +76,7 @@ class JlinkTaskImpl extends BaseTaskImpl<JlinkTaskData> {
 
     @CompileDynamic
     void runJlink(File imageDir, String jdkHome, List<String> extraModulePaths, List<String> options) {
-        if(!new File("$jdkHome/jmods/java.base.jmod").file) {
+        if(!new File("$jdkHome/jmods/java.base.jmod").file && JavaVersion.get(jdkHome) < 24) {
             throw new GradleException("java.base module not found in $jdkHome${File.separator}jmods")
         }
         project.delete(imageDir)


### PR DESCRIPTION
Partially fixes https://github.com/beryx/badass-jlink-plugin/issues/299
At least it makes it so that you can compile again.