### PR TITLE
Use exec in Unix launcher script to forward signals

### DIFF
--- a/src/main/resources/unixScriptTemplate.txt
+++ b/src/main/resources/unixScriptTemplate.txt
@@ -12,4 +12,4 @@ if [ -f "\$CDS_ARCHIVE_FILE" ]; then
 fi
 <% } %>
 
-"\$DIR/java" \$CDS_JVM_OPTS ${jvmArgs} -p "\$DIR/../app" -m ${moduleName}/${mainClassName} ${args} "\$@"
+exec "\$DIR/java" \$CDS_JVM_OPTS ${jvmArgs} -p "\$DIR/../app" -m ${moduleName}/${mainClassName} ${args} "\$@"


### PR DESCRIPTION
## Problem

The generated Unix launcher script starts the JVM as a child process of the shell:

```sh
"$DIR/java" ... -m ${moduleName}/${mainClassName} "$@"
```

When running under a process supervisor (like systemd) or inside a container runtime (Docker/Kubernetes/Podman), the wrapper shell becomes the parent process (or PID 1 in containers). The orchestrator sends a `SIGTERM` to the shell to request graceful shutdown, but that signal is delivered to the shell - not to the Java process. As a result, the JVM never receives `SIGTERM`, shutdown hooks never run, and the process is eventually force-killed with `SIGKILL` after the grace period expires.

## Fix

Prefix the Java invocation with `exec` so the shell replaces itself with the JVM, making Java inherit the PID and directly receive all system signals:

```sh
exec "$DIR/java" ... -m ${moduleName}/${mainClassName} "$@"
```